### PR TITLE
Fix for compiling and installing on Mac.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ ps2-packer
 ps2-packer-lite
 # TODO: OS X build products (.dsym, .dylib, etc)
 
+*.dylib

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ ifeq ($(SYSTEM),Darwin)
 CPPFLAGS += -D__APPLE__
 SHARED = -dynamiclib
 SHAREDSUFFIX = .dylib
+CC = /usr/bin/gcc
+CPPFLAGS += -I/opt/local/include -L/opt/local/lib
+BIN2O = /usr/bin/ld -r -arch x86_64
 else
 SHARED = -shared
 SHAREDSUFFIX = .so
@@ -24,15 +27,15 @@ endif
 
 PACKERS = zlib-packer lzo-packer n2b-packer n2d-packer n2e-packer null-packer
 
-all: ps2-packer ps2-packer-lite packers stubs
+all: ps2-packer packers stubs
 
 install: all
 	$(INSTALL) -d $(PREFIX)/bin
 	$(INSTALL) -d $(PREFIX)/share/ps2-packer/module
 	$(INSTALL) -d $(PREFIX)/share/ps2-packer/stub
-	$(INSTALL) ps2-packer $(PREFIX)/bin -m 755
-	$(INSTALL) $(addsuffix $(SHAREDSUFFIX),$(PACKERS)) $(PREFIX)/share/ps2-packer/module -m 755
-	$(INSTALL) ps2-packer $(PREFIX)/bin -m 755
+	$(INSTALL) -m 755 ps2-packer $(PREFIX)/bin
+	$(INSTALL) -m 755 $(addsuffix $(SHAREDSUFFIX),$(PACKERS)) $(PREFIX)/share/ps2-packer/module
+	$(INSTALL) -m 755 ps2-packer $(PREFIX)/bin
 	PREFIX=$(PREFIX) $(SUBMAKE) stub install
 
 ps2-packer: ps2-packer.c dlopen.c

--- a/stub/Makefile
+++ b/stub/Makefile
@@ -22,7 +22,7 @@ n2e-asm-1d00-stub n2e-asm-one-1d00-stub
 all: $(TARGETS)
 
 install: all
-	install $(TARGETS) $(PREFIX)/share/ps2-packer/stub -m 644
+	install -m 644 $(TARGETS) $(PREFIX)/share/ps2-packer/stub
 
 dist: $(TARGETS)
 	ee-strip $(TARGETS)


### PR DESCRIPTION
This commit includes several changes to allow compiling on Mac OS X with the current PS2SDK:

 * Change the argument order to `install` to be compatible to BSD
 * Add Mac shared libraries to `.gitignore` file
 * Fix the gcc path and ld path and invocation on OS X, to be compatible to different installed gcc versions
 * Add the MacPorts directory to the search part to be comaptible with `port install ucl`
 * Don't build ps2-packer-lite by default, it isn't installed anyway and has build problems