### PR TITLE
Fix Makefiles for other platforms.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 PREFIX = $(PS2DEV)
 
-MAKE = make
-SUBMAKE = MAKE=$(MAKE) $(MAKE) -C
+SUBMAKE = $(MAKE) -C
 SHELL = /bin/sh
 SYSTEM = $(shell uname)
 LIBZA = -lz

--- a/stub/Makefile
+++ b/stub/Makefile
@@ -1,4 +1,4 @@
-SUBMAKE = MAKE=$(MAKE) $(MAKE) -C
+SUBMAKE = $(MAKE) -C
 
 include $(PS2SDK)/Defs.make
 


### PR DESCRIPTION
This was added to fix building on macOS, but I don't see why they would need to specify $MAKE as make. Also one $MAKE should be enough in $SUBMAKE.
Hopefully this won't break macOS, but the current Makefiles don't work on systems with other default make than GNU Make.