### PR TITLE
fix bin2c path if have installed other program with the same name (ex…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SYSTEM = $(shell uname)
 LIBZA = -lz
 LIBUCLA = -lucl
 VERSION = 1.1.0
-BIN2C = bin2c
+BIN2C = $(PS2SDK)/bin/bin2c
 CPPFLAGS = -O3 -Wall -I. -DVERSION=\"$(VERSION)\" -DPREFIX=\"$(PREFIX)\"
 INSTALL = install
 


### PR DESCRIPTION
…ample: pspsdk)

see https://github.com/ps2dev/ps2-packer/issues/16#issuecomment-416061092