### PR TITLE
Set LZMA as default packer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,16 +66,11 @@ uninstall:
 ps2-packer: ps2-packer.c dlopen.c
 	$(CC) $(CPPFLAGS) ps2-packer.c dlopen.c $(LDFLAGS) -o ps2-packer$(EXECSUFFIX)
 
-ps2-packer-lite: ps2-packer.c builtin_stub_one.o builtin_stub.o
-	$(CC) $(CPPFLAGS) -DPS2_PACKER_LITE ps2-packer.c n2e-packer.c $(LIBUCLA) builtin_stub_one.o builtin_stub.o $(LDFLAGS) -o ps2-packer-lite$(EXECSUFFIX)
-
-builtin_stub_one.c: stubs-tag.stamp
-	cp stub/n2e-asm-one-1d00-stub ./b_stub_one
-	$(BIN2C) b_stub_one builtin_stub_one.c builtin_stub_one
-	rm b_stub_one
+ps2-packer-lite: ps2-packer.c builtin_stub.o lzma
+	$(CC) $(CPPFLAGS) $(LZMA_CPPFLAGS) -DPS2_PACKER_LITE ps2-packer.c lzma-packer.c $(LIBLZMAA) builtin_stub.o $(LDFLAGS) -o ps2-packer-lite$(EXECSUFFIX)
 
 builtin_stub.c: stubs-tag.stamp
-	cp stub/n2e-asm-1d00-stub ./b_stub
+	cp stub/lzma-1d00-stub ./b_stub
 	$(BIN2C) b_stub builtin_stub.c builtin_stub
 	rm b_stub
 
@@ -125,7 +120,7 @@ stubs-dist:
 	$(SUBMAKE) stub dist
 
 clean:
-	rm -f ps2-packer ps2-packer-lite ps2-packer.exe ps2-packer-lite.exe *.zip *.gz *.dll builtin_stub.c builtin_stub_one.c *$(SHAREDSUFFIX) *.o
+	rm -f ps2-packer ps2-packer-lite ps2-packer.exe ps2-packer-lite.exe *.zip *.gz *.dll builtin_stub.c *$(SHAREDSUFFIX) *.o
 	$(SUBMAKE) lzma clean
 	rm -f lzma-tag.stamp
 	$(SUBMAKE) stub clean

--- a/README-lite.txt
+++ b/README-lite.txt
@@ -5,9 +5,9 @@ Overview
 --------
 
   This is the lite version of PS2-Packer. See README.txt for full details
-about that software. This lite version only comes with built-in ucl n2e packer
-and unpackers. That means you don't need any external file to use it, if you
-only want to use the n2e compression, which is what most people want to do
+about that software. This lite version only comes with built-in lzma packer
+and unpacker. That means you don't need any external file to use it, if you
+only want to use the lzma compression, which is what most people want to do
 anyway. This is also a request, to resolve cygwin's path problems.
 
 

--- a/README.txt
+++ b/README.txt
@@ -7,7 +7,8 @@ Overview
   Just like UPX http://upx.sourceforge.net/ this tool is designed to help you
 create packed ELF to run on the PS2. It has a modular design, so anybody can
 write any kind of module to it. It actually has a zlib module, a lzo module,
-three ucl modules (n2b, n2d and n2e) and a null module, for demo purpose only.
+a lz4 module, a lzma module, three ucl modules (n2b, n2d and n2e) and a null
+module, for demo purpose only.
 
 
 Changelog
@@ -158,9 +159,9 @@ How it works
     -v             verbose mode.
     -b base        sets the loading base of the compressed data. When activated
                       it will activate the alternative packing way. See below.
-    -p packer      sets a packer name. n2e by default.
-    -s stub        sets another uncruncher stub. stub/n2e-1d00-stub by default,
-                      or stub/n2e-0088-stub when using alternative packing.
+    -p packer      sets a packer name. lzma by default.
+    -s stub        sets another uncruncher stub. stub/lzma-1d00-stub by default,
+                      or stub/lzma-0088-stub when using alternative packing.
     -r reload      sets a reload base of the stub. Beware, that will only works
                       with the special asm stubs.
     -a align       sets section alignment. 16 by default. Any value accepted.

--- a/ps2-packer.c
+++ b/ps2-packer.c
@@ -240,9 +240,9 @@ void show_usage() {
 	"    -b base        sets the loading base of the compressed data. When activated\n"
 	"                     it will activate the alternative packing way.\n"
 #ifndef PS2_PACKER_LITE
-        "    -p packer      sets a packer name. n2e by default.\n"
-	"    -s stub        sets another uncruncher stub. stub/n2e-asm-1d00-stub,\n"
-	"                     or stub/n2e-0088-stub when using alternative packing.\n"
+        "    -p packer      sets a packer name. lzma by default.\n"
+	"    -s stub        sets another uncruncher stub. stub/lzma-1d00-stub by default,\n"
+	"                     or stub/lzma-0088-stub when using alternative packing.\n"
 #endif
 	"    -r reload      sets a reload base of the stub. Beware, that will only works\n"
 	"                     with the special asm stubs.\n"
@@ -331,7 +331,6 @@ int count_sections(FILE * stub) {
 }
 
 #ifdef PS2_PACKER_LITE
-extern u8 builtin_stub_one[];
 extern u8 builtin_stub[];
 #endif
 
@@ -358,11 +357,7 @@ void load_stub(
       printe("fread error\n");
     }
 #else
-    if (sections == 1) {
-	loadbuf = builtin_stub_one;
-    } else {
-	loadbuf = builtin_stub;
-    }
+    loadbuf = builtin_stub;
 #endif
 
     eh = (elf_header_t *)loadbuf;
@@ -756,7 +751,7 @@ int main(int argc, char ** argv) {
 
 #ifndef PS2_PACKER_LITE
     if (!packer_name) {
-	packer_name = "n2e";
+	packer_name = "lzma";
     }
 
     if (!stub_name) {
@@ -807,8 +802,6 @@ int main(int argc, char ** argv) {
     }
 
     packer_dll = strdup(buffer);
-#else
-    use_asm_n2e = ((sections == 1) ? 2 : 1);
 #endif
 
     printf("Compressing %s...\n", in_name);


### PR DESCRIPTION
For testing purposes, I have included ps2-packer binaries for the platforms listed below.

Test builds:

- linux-32bit: http://www.mediafire.com/file/2xtvt81h0akwmpx/ps2-packer-lzma-linux32.tar.xz/file
- linux-64bit: http://www.mediafire.com/file/21e9fp5y4udx7z4/ps2-packer-lzma-linux64.tar.xz/file
- windows-32bit: http://www.mediafire.com/file/camizjwdbrbz4oz/ps2-packer-lzma-win32.7z/file
- windows-64bit: http://www.mediafire.com/file/4eosg2t1bw8f10i/ps2-packer-lzma-win64.7z/file