### PR TITLE
Fix warnings compiling in OSX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ ifeq ($(SYSTEM),Darwin)
 	SHARED = -dynamiclib
 	SHAREDSUFFIX = .dylib
 	CC = /usr/bin/gcc
-	CPPFLAGS += -I/opt/local/include -L/opt/local/lib
+	CPPFLAGS += -I/usr/local/include -L/usr/local/lib
 else ifeq ($(OS),Windows_NT)
 	SHAREDSUFFIX = .dll
 	EXECSUFFIX = .exe


### PR DESCRIPTION
## Description
This PR fixes warnings in the compilation in OSX because it used directories that don't exist in the operating system.

Thanks