### PR TITLE
add #include for memcpy to fix compile error on clang 12

### DIFF
--- a/common/lzma/MtDec.c
+++ b/common/lzma/MtDec.c
@@ -5,7 +5,7 @@
 
 // #define SHOW_DEBUG_INFO
 
-// #include <stdio.h>
+#include <string.h>
 
 #ifdef SHOW_DEBUG_INFO
 #include <stdio.h>


### PR DESCRIPTION
Let's #include string.h so we get memcpy. Fixes this diagnostic when compiling with clang 12:

```
../common/lzma/MtDec.c:449:19: error: implicitly declaring library function
      'memcpy' with type 'void *(void *, const void *, unsigned long)'
      [-Werror,-Wimplicit-function-declaration]
```