### PR TITLE
Remove remnants of support code intended for use with UCL packers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ genuine ps2dev website, that is, http://ps2dev.org
 
 # How it works
 ```
-  Usage: ps2-packer [-v] [-b X] [-p X] [-s X] [-a X] [-r X] <in_elf> <out_elf>
+  Usage: ps2-packer [-v] [-b X] [-p X] [-s X] [-a X] <in_elf> <out_elf>
   
   Options description:
     -v             verbose mode.
@@ -63,8 +63,6 @@ genuine ps2dev website, that is, http://ps2dev.org
     -p packer      sets a packer name. lzma by default.
     -s stub        sets another uncruncher stub. stub/lzma-1d00-stub by default,
                       or stub/lzma-0088-stub when using alternative packing.
-    -r reload      sets a reload base of the stub. Beware, that will only works
-                      with the special asm stubs.
     -a align       sets section alignment. 16 by default. Any value accepted.
                       However, here is a list of alignments to know:
 		1 - no alignment, risky, shouldn't work.
@@ -85,9 +83,6 @@ will be forced to reside at a certain location. That's the alternative packing
 method. The output elf will contain two program sections. The first one will
 be the uncruncher stub. The second section contains the packed data, loaded at
 the address you specified.
-
-  The reload option is meant to forcibily relink the stub to another address.
-This will only work with the asm stubs though; be careful when using it.
 
   So, depending on your needs, just move the data around, to get the desired
 results.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Is being done following a modular design, so anybody can write any kind of modul
  - `lzo` module.
  - `lz4` module.
  - `lzma` module. 
- - Three `ucl` modules (n2b, n2d and n2e)
  - `null` module, for demo purpose only.
 
 # TODO

--- a/ps2-packer.c
+++ b/ps2-packer.c
@@ -54,8 +54,6 @@ u32 stub_size;  /* Size of the stub section */
 u32 stub_zero;  /* Number of bytes to zero-pad at the end of the section */
 u32 stub_signature; /* packer signature located in the stub */
 
-u32 reload = 0;
-
 u8 alternative = 0; /* boolean for alternative loading method */
 u32 alignment = 0x10;
 
@@ -67,7 +65,6 @@ u32 data_pointer;
 struct option long_options[] = {
     {"help",    0, NULL, 'h'},
     {"base",    1, NULL, 'b'},
-    {"reload",  1, NULL, 'r'},
 #ifndef PS2_PACKER_LITE
     {"packer",  1, NULL, 'p'},
     {"stub",    1, NULL, 's'},
@@ -232,7 +229,7 @@ void show_usage() {
 #ifndef PS2_PACKER_LITE
 	"[-p X] [-s X] "
 #endif
-	"[-r X] <in_elf> <out_elf>\n"
+	"<in_elf> <out_elf>\n"
 	"    -h             show this help.\n"
 	"    -v             verbose mode.\n"
 	"    -b base        sets the loading base of the compressed data. When activated\n"
@@ -242,8 +239,6 @@ void show_usage() {
 	"    -s stub        sets another uncruncher stub. stub/lzma-1d00-stub by default,\n"
 	"                     or stub/lzma-0088-stub when using alternative packing.\n"
 #endif
-	"    -r reload      sets a reload base of the stub. Beware, that will only works\n"
-	"                     with the special asm stubs.\n"
 	"    -a align       sets section alignment. 16 by default. Any value accepted.\n"
     );
 }
@@ -344,10 +339,6 @@ void load_stub(
 
 	stub_base = eph[i].vaddr;
 	stub_zero = eph[i].memsz - eph[i].filesz;
-
-	if (reload != 0)
-	    stub_base = reload;
-
 
 	loaded = 1;
 	break;
@@ -641,7 +632,7 @@ int main(int argc, char ** argv) {
 #ifndef PS2_PACKER_LITE
 	        "p:s:"
 #endif
-		"hvr:", long_options, NULL)) != EOF) {
+		"hv", long_options, NULL)) != EOF) {
 	switch (c) {
 	case 'b':
 	    base = strtoul(optarg, NULL, 0);
@@ -658,9 +649,6 @@ int main(int argc, char ** argv) {
 	    stub_name = strdup(optarg);
 	    break;
 #endif
-	case 'r':
-	    reload = strtoul(optarg, NULL, 0);
-	    break;
 	case 'v':
 	    verbose = 1;
 	    break;


### PR DESCRIPTION
Support code no longer needed since commit e3ceaec5b760f8dd49ae92b6290a35cd43979d28 ("`Remove ucl and fix lzma compilation issues`").