### PR TITLE
fix packer invocation on cygwin

### DIFF
--- a/ps2-packer.c
+++ b/ps2-packer.c
@@ -29,7 +29,7 @@
 #include "dlopen.h"
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__CYGWIN__)
 #define SUFFIX ".dll"
 #elif defined (__APPLE__)
 #define SUFFIX ".dylib"


### PR DESCRIPTION
cygwin uses .dll, not .so, for its libraries