### PR TITLE
Swap char for int to fix arg parsing on systems where char is unsigned

### DIFF
--- a/ps2-packer.c
+++ b/ps2-packer.c
@@ -585,7 +585,7 @@ int file_exists(const char * fname) {
 }
 
 int main(int argc, char ** argv) {
-    char c;
+    int c;
     u32 base = 0;
 #ifndef PS2_PACKER_LITE
     char buffer[BUFSIZ + 1];


### PR DESCRIPTION
On certain systems (notably ARM64?) `char` might not necessarily be signed. This causes issues when ps2-packer tries to read arguments as it can't check for `EOF` properly.

This PR changes the data type of the variable used to store the value returned from getopt to an `int`, which fixes argument parsing on these systems.

Fixes #43 